### PR TITLE
fix: don't crash when powerlevel cannot be read

### DIFF
--- a/Test/RangeTesting/ZWJSRangeTest.js
+++ b/Test/RangeTesting/ZWJSRangeTest.js
@@ -143,7 +143,12 @@ async function main() {
 
   await setTimeout(5000);
 
-  const defaultMeshTxPower = (await driver.controller.getPowerlevel()).powerlevel;
+  let defaultMeshTxPower;
+  try {
+    defaultMeshTxPower = (await driver.controller.getPowerlevel()).powerlevel;
+  } catch {
+    defaultMeshTxPower = 0
+  }
   
   const start = new Date();
 


### PR DESCRIPTION
You may want to set the default to something else than 0 dBm in the error case. This value is meant to go into the CSV as the powerlevel in case the controller does not report the actual TX powerlevel.